### PR TITLE
Fix links for GitHub repo and email

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -47,7 +47,7 @@ social-network-links:
   email: "heidib@stanford.edu"
   rss: true  # remove this line if you don't want to show an RSS link at the bottom
 #  facebook: deanattali
-  github: bigteamscience
+  github: bigteamsciencelab
 #  twitter: daattali
 #  patreon: DeanAttali
 #  youtube: c/daattali

--- a/events.md
+++ b/events.md
@@ -11,11 +11,11 @@ cover-img: /assets/img/events_blank.png
 ### April 29, 2022 10-11:30am PT on Zoom
 ## *Panel:* Authorship challenges in big team science
 
-The rise of big team science (Coles et al., 2022) has vitalized conversations about how scientific contributions are recognized and rewarded. For example, what constitutes authorship in science? Perspectives on this issue vary both within and between individual researchers, scientific organizations, publishers, and science stakeholders. For example, some groups have developed models that distinguish between (a) author vs. non-author contributions, (b) individual vs. group contributions, and so on (Council of Science Editors, 2006). Others have endorsed models that do not make such distinctions and instead include taxonomies for describing the nature of researchers’ contributions (Allen, Brand, Scott, Altman, & Hlava, 2014; Holcombe, 2019; Moshontz et al., 2018). 
+The rise of big team science (Coles et al., 2022) has vitalized conversations about how scientific contributions are recognized and rewarded. For example, what constitutes authorship in science? Perspectives on this issue vary both within and between individual researchers, scientific organizations, publishers, and science stakeholders. For example, some groups have developed models that distinguish between (a) author vs. non-author contributions, (b) individual vs. group contributions, and so on (Council of Science Editors, 2006). Others have endorsed models that do not make such distinctions and instead include taxonomies for describing the nature of researchers’ contributions (Allen, Brand, Scott, Altman, & Hlava, 2014; Holcombe, 2019; Moshontz et al., 2018).
 
 This panel will bring together diverse perspectives to discuss various authorship challenges in big team science. This will include (1) decisions about consortium vs. non-consortium authorship, (2) handling authorship disputes, (3) collaboration agreements, (4) acknowledging diverse contributions, and (5) navigating differences in authorship standards. Attendees will also be encouraged to bring their own questions and contribute to the conversation.
 
-### Panelists 
+### Panelists
 * **Flávio Azevedo**, *co-developer of the [Framework for Open and Reproducible Research Training (FORRT)](https://forrt.org)*
 * **Nicholas Coles**, *director of the [Psychological Science Accelerator (PSA)](https://psysciacc.org/)*
 * **Lisa DeBruine**, *member of the American Psychological Association’s [Publications and Communications Board](https://www.apa.org/about/governance/bdcmte/publication)*
@@ -30,7 +30,7 @@ A recording of the panel is available [here](https://stanford.zoom.us/rec/play/2
 
 ### Contact Us
 
-Email the organizers: [Heidi Baumgartner](mailto:heidib@stanford.edu), [Nicholas Coles](ncoles@stanford.edu) 
+Email the organizers: [Heidi Baumgartner](mailto:heidib@stanford.edu), [Nicholas Coles](mailto:ncoles@stanford.edu) 
 
 ***
 
@@ -44,5 +44,3 @@ Email the organizers: [Heidi Baumgartner](mailto:heidib@stanford.edu), [Nicholas
 
 ### Get involved
 We encourage everyone who is interested in Big Team Science to [get involved]({{site.baseurl}}/get_involved/).
-
-


### PR DESCRIPTION
Just fixing a couple of broken links that I came across:
* GitHub icon in footer now links to https://github.com/bigteamsciencelab instead of https://github.com/bigteamscience
* Added missing `mailto:` to email link on Events page